### PR TITLE
Update Audi Q8 e-tron generations: correct timeline and production history

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
-# Model make
+# Audi Q8 e-tron
+
+This repository contains signal set configurations for the Audi Q8 e-tron, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Audi Q8 e-tron.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.
 

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,5 +1,8 @@
+references:
+  - "https://en.wikipedia.org/wiki/Audi_Q8_e-tron"
+
 generations:
-  - name: "First Generation"
-    start_year: 2023
-    end_year: null
-    description: "The Audi Q8 e-tron is the renamed and significantly updated continuation of the original Audi e-tron. This mid-size luxury electric SUV features revised styling with a new enclosed Singleframe grille design and updated lighting signatures. The most significant improvements are technical: battery capacity increased to 106 kWh (from 95 kWh), providing an extended range of up to 360-380 miles (WLTP) depending on the variant. Motor efficiency and thermal management were also improved. Like its predecessor, the Q8 e-tron is available in both standard SUV and Sportback body styles with a choice of dual-motor powertrains. The Q8 e-tron 55 produces up to 402 HP in boost mode, while the Q8 e-tron S features a three-motor setup (one front, two rear) generating 496 HP. The interior maintains Audi's premium quality with updated technology and increased use of sustainable materials. The Q8 e-tron represents Audi's ongoing refinement of its electric vehicle technology and positions the vehicle more clearly within the brand's naming hierarchy."
+  - name: "First Generation (Audi e-tron / Q8 e-tron)"
+    start_year: 2018
+    end_year: 2025
+    description: "The Audi Q8 e-tron (formerly the Audi e-tron from 2018 to 2023) is a battery electric mid-size luxury crossover SUV produced by Audi since 2018. The e-tron was unveiled as a concept car at the 2015 Frankfurt Motor Show and the final production version was revealed on September 17, 2018. It was first delivered in May 2019, making it Audi's first battery electric mass production car. The Sportback variant, featuring a coupe-style roof, entered production in early 2020. In 2022, the vehicle underwent a significant facelift and was renamed to the Audi Q8 e-tron (with the performance version called SQ8 e-tron), offered in both regular and Sportback body styles. Key improvements in the facelifted Q8 e-tron include an updated design with a new enclosed Singleframe grille and revised lighting, increased battery capacity from 95 kWh to 114 kWh (106 kWh usable), and improved motor efficiency. The Q8 e-tron is available in multiple variants including 50, 55, and performance S/SQ8 versions. Production concluded in February 2025."


### PR DESCRIPTION
- Corrected start year from 2023 to 2018 (actual production start)
- Updated end year from null to 2025 (February 2025 production end)
- Clarified the single generation spanning 2018-2025 with naming change
- Added detail about the 2022 facelift and Q8 e-tron rename (not a new generation)
- Included Sportback variant introduction in early 2020
- Updated battery specifications and variant information per Wikipedia

Evidence: Wikipedia article states "Audi Q8 e-tron" with "aka = Audi e-tron (2018–2023)" and "production = 2018 – February 2025"

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
